### PR TITLE
Fix Python 3.8 tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands =
     coverage xml
 
 [testenv:flake8]
-basepython = python3.9
+basepython = python3.8
 commands = flake8 dbtemplates
 deps = flake8
 


### PR DESCRIPTION
I think your PR (https://github.com/jazzband/django-dbtemplates/pull/118) is probably dead in the water, but just in case they are waiting for passing tests. It appears that flake fails because it is run under [python3.8](https://github.com/wamberg/django-dbtemplates/compare/cache-compat-%23116...whikloj:fix-tests?expand=1#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R14) but has a base python set to 3.9. This changes the base python, alternatively I think you could move flake8 to the py39 github action.